### PR TITLE
feedwriter was not restarted in case of export failure

### DIFF
--- a/emoncms-export.sh
+++ b/emoncms-export.sh
@@ -32,7 +32,6 @@ then
     sudo rm $backup_location/emoncms-backup-$date.tar
 fi
 
-
 #-----------------------------------------------------------------------------------------------
 # Check emonPi / emonBase image version
 #-----------------------------------------------------------------------------------------------
@@ -56,8 +55,6 @@ else
 fi
 #-----------------------------------------------------------------------------------------------
 
-
-
 sudo service feedwriter stop
 
 # Get MYSQL authentication details from settings.php
@@ -67,6 +64,7 @@ if [ -f /home/pi/backup/get_emoncms_mysql_auth.php ]; then
 else
     echo "Error: cannot read MYSQL authentication details from Emoncms settings.php"
     echo "$PWD"
+    sudo service feedwriter start > /dev/null
     exit 1
 fi
 
@@ -76,11 +74,13 @@ if [ -n "$username" ]; then # if username string is not empty
     if [ $? -ne 0 ]; then
         echo "Error: failed to export mysql data"
         echo "emoncms export failed"
+        sudo service feedwriter start > /dev/null
         exit 1
     fi
 
 else
     echo "Error: Cannot read MYSQL authentication details from Emoncms settings.php"
+    sudo service feedwriter start > /dev/null
     exit 1
 fi
 
@@ -93,6 +93,7 @@ if [ $image="old" ]; then
   if [ $? -ne 0 ]; then
       echo "Error: failed to tar config data"
       echo "emoncms export failed"
+      sudo service feedwriter start > /dev/null
       exit 1
   fi
 fi
@@ -104,6 +105,7 @@ if [ $image="new" ]; then
   if [ $? -ne 0 ]; then
       echo "Error: failed to tar config data"
       echo "emoncms export failed"
+      sudo service feedwriter start > /dev/null
       exit 1
   fi
 fi
@@ -113,6 +115,7 @@ tar --append --file=$backup_location/emoncms-backup-$date.tar -C $mysql_path php
 if [ $? -ne 0 ]; then
     echo "Error: failed to tar mysql dump and data"
     echo "emoncms export failed"
+    sudo service feedwriter start > /dev/null
     exit 1
 fi
 
@@ -122,6 +125,7 @@ gzip -f $backup_location/emoncms-backup-$date.tar 2>&1
 if [ $? -ne 0 ]; then
     echo "Error: failed to compress tar file"
     echo "emoncms export failed"
+    sudo service feedwriter start > /dev/null
     exit 1
 fi
 


### PR DESCRIPTION
In case of failure, export script exited but was not restarting feedwriter