### PR TITLE
Import/ Export cleanup

### DIFF
--- a/emoncms-export.sh
+++ b/emoncms-export.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-script_location="`dirname $0`"
+script_location="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 config_location=${script_location}/config.cfg
 
 date=$(date +"%Y-%m-%d")

--- a/emoncms-export.sh
+++ b/emoncms-export.sh
@@ -18,7 +18,7 @@ then
     echo "Location of Emoncms: $emoncms_location"
     echo "Backup destination: $backup_location"
 else
-    echo "ERROR: Backup ${config_location} file does not exist"
+    echo "ERROR: Backup config file ${config_location} does not exist"
     exit 1
     sudo systemctl start feedwriter > /dev/null
 fi

--- a/emoncms-export.sh
+++ b/emoncms-export.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
 script_location="`dirname $0`"
+config_location=${script_location}/config.cfg
 
 date=$(date +"%Y-%m-%d")
 
 echo "=== Emoncms export start ==="
 date
 echo "Backup module version:"
-cat $script_location/backup-module/module.json | grep version
+grep version ${script_location}/module.json
 echo "EUID: $EUID"
-echo "Reading $script_location/config.cfg...."
-if [ -f "$script_location/config.cfg" ]
+echo "Reading ${config_location}...."
+if [ -f "${config_location}" ]
 then
-    source "$script_location/config.cfg"
+    source "${config_location}"
     echo "Location of databases: $database_path"
     echo "Location of emonhub.conf: $emonhub_config_path"
     echo "Location of Emoncms: $emoncms_location"
     echo "Backup destination: $backup_location"
 else
-    echo "ERROR: Backup $script_location/backup/config.cfg file does not exist"
+    echo "ERROR: Backup ${config_location} file does not exist"
     exit 1
     sudo systemctl start feedwriter > /dev/null
 fi

--- a/emoncms-export.sh
+++ b/emoncms-export.sh
@@ -20,7 +20,6 @@ then
 else
     echo "ERROR: Backup config file ${config_location} does not exist"
     exit 1
-    sudo systemctl start feedwriter > /dev/null
 fi
 
 module_location="${emoncms_location}/Modules/backup"

--- a/emoncms-import.sh
+++ b/emoncms-import.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-script_location="`dirname $0`"
+script_location="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 config_location=${script_location}/config.cfg
 
 echo "=== Emoncms import start ==="

--- a/emoncms-import.sh
+++ b/emoncms-import.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
 
 script_location="`dirname $0`"
+config_location=${script_location}/config.cfg
 
 echo "=== Emoncms import start ==="
 date +"%Y-%m-%d-%T"
 echo "Backup module version:"
-cat $script_location/backup/module.json | grep version
+grep version ${script_location}/module.json
 echo "EUID: $EUID"
-echo "Reading $script_location/config.cfg...."
-if [ -f "$script_location/config.cfg" ]
+echo "Reading ${config_location}...."
+if [ -f "${config_location}" ]
 then
-    source "$script_location/config.cfg"
+    source "${config_location}"
     echo "Location of data databases: $database_path"
     echo "Location of emonhub.conf: $emonhub_config_path"
     echo "Location of Emoncms: $emoncms_location"
     echo "Backup destination: $backup_location"
     echo "Backup source path: $backup_source_path"
 else
-    echo "ERROR: Backup $script_location/backup/config.cfg file does not exist"
+    echo "ERROR: Backup ${config_location} file does not exist"
     exit 1
 fi
 

--- a/emoncms-import.sh
+++ b/emoncms-import.sh
@@ -53,8 +53,8 @@ fi
 
 
 # Get latest backup filename
-if [ ! -d $backup_source_path ]; then
-	echo "Error: $backup_source_path does not exist, nothing to import"
+if [ ! -d "${backup_source_path}" ]; then
+	echo "Error: ${backup_source_path} does not exist, nothing to import"
 	exit 1
 fi
 
@@ -69,8 +69,8 @@ fi
 echo "Backup found: ${backup_filename} starting import.."
 
 echo "Read MYSQL authentication details from settings.php"
-if [ -f $script_location/get_emoncms_mysql_auth.php ]; then
-    auth=$(echo $emoncms_location | php $script_location/get_emoncms_mysql_auth.php php)
+if [ -f "${script_location}/get_emoncms_mysql_auth.php" ]; then
+    auth=$(echo "${emoncms_location}" | php "${script_location}/get_emoncms_mysql_auth.php" php)
     IFS=":" read username password database <<< "$auth"
 else
     echo "Error: cannot read MYSQL authentication details from Emoncms settings.php"
@@ -119,7 +119,7 @@ then # if username sring is not empty
             sudo systemctl stop emoncms_mqtt
         fi
         echo "Emoncms MYSQL database import..."
-        mysql -u$username -p$password $database < "${import_location}/emoncms.sql"
+        mysql -u"${username}" -p"${password}" "${database}" < "${import_location}/emoncms.sql"
 	if [ $? -ne 0 ]; then
 		echo "Error: failed to import mysql data"
 		echo "Import failed"
@@ -135,17 +135,17 @@ else
 fi
 
 echo "Import feed meta data.."
-sudo rm -rf $database_path/{phpfina,phptimeseries} 2> /dev/null
+sudo rm -rf "${database_path}"/{phpfina,phptimeseries} 2> /dev/null
 
 echo "Restore phpfina and phptimeseries data folders..."
 if [ -d "${import_location}/phpfina" ]; then
 	sudo mv "${import_location}/phpfina" "${database_path}"
-	sudo chown -R www-data:root $database_path/phpfina
+	sudo chown -R www-data:root "${database_path}/phpfina"
 fi
 
 if [ -d "${import_location}/phptimeseries" ]; then
 	sudo mv "${import_location}/phptimeseries" "${database_path}"
-	sudo chown -R www-data:root $database_path/phptimeseries
+	sudo chown -R www-data:root "${database_path}/phptimeseries"
 fi
 
 # cleanup
@@ -156,7 +156,7 @@ if [ -f "${import_location}/emonhub.conf" ]; then
     if [ -d "${emonhub_config_path}" ]; then
         echo "Import emonhub.conf > ${emonhub_config_path}/emohub.conf"
         sudo mv "${import_location}/emonhub.conf" "${emonhub_config_path}/emonhub.conf"
-        sudo chmod 666 $emonhub_config_path/emonhub.conf
+        sudo chmod 666 "${emonhub_config_path}/emonhub.conf"
     else
         echo "WARNING: emonhub.conf found in backup, but no emonHub directory (${emonhub_config_path}) found"
     fi

--- a/emoncms-import.sh
+++ b/emoncms-import.sh
@@ -18,7 +18,7 @@ then
     echo "Backup destination: $backup_location"
     echo "Backup source path: $backup_source_path"
 else
-    echo "ERROR: Backup ${config_location} file does not exist"
+    echo "ERROR: Backup config file ${config_location} does not exist"
     exit 1
 fi
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Install this module in /opt/emoncms/modules:
     
 Run backup module installation script to modify php.ini and setup uploads folder:
 
+    cd backup
     ./install.sh
 
 ## Manual Export Instructions

--- a/usb-import.sh
+++ b/usb-import.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
 
 script_location="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+config_location=${script_location}/config.cfg
 
 echo "=== USB Emoncms import start ==="
 date +"%Y-%m-%d-%T"
 echo "Backup module version:"
-cat $script_location/backup-module/module.json | grep version
+grep version ${script_location}/module.json
 echo "EUID: $EUID"
-echo "Reading $script_location/config.cfg...."
-if [ -f "$script_location/config.cfg" ]
+echo "Reading ${config_location}...."
+if [ -f "${config_location}" ]
 then
-    source "$script_location/config.cfg"
+    source "${config_location}"
     echo "Location of data databases: $database_path"
     echo "Location of emonhub.conf: $emonhub_config_path"
     echo "Location of Emoncms: $emoncms_location"
 else
-    echo "ERROR: Backup $script_location/backup/config.cfg file does not exist"
+    echo "ERROR: Backup ${config_location} file does not exist"
     exit 1
 fi
 

--- a/usb-import.sh
+++ b/usb-import.sh
@@ -16,7 +16,7 @@ then
     echo "Location of emonhub.conf: $emonhub_config_path"
     echo "Location of Emoncms: $emoncms_location"
 else
-    echo "ERROR: Backup ${config_location} file does not exist"
+    echo "ERROR: Backup config file ${config_location} does not exist"
     exit 1
 fi
 


### PR DESCRIPTION
Cleanup of readme.md to include "cd backup" to ensure the user is in the correct directory first.

Changes to emoncms-export.sh, emoncms-import.sh and usb-import.sh to correct location of module.json, making config.cfg locations consistent as some output differs from the real location and change the script location to always show the full path even when triggered by ./emoncms-export.sh (approach copied from usb-import.sh)

I've tested the scripts without a config.cfg.

![image](https://user-images.githubusercontent.com/33792140/221440129-7fd411ef-6d46-4324-915a-8dbe7018799a.png)

The other scripts provide effectively identical output.

And when config.cfg exists:
![image](https://user-images.githubusercontent.com/33792140/221440259-8b1652e1-9ef3-4275-9f89-c0ca080ded0b.png)

Again the other scripts provide an effectively identical output.