### PR TITLE
Add hostname and error handling to the export process

### DIFF
--- a/backup-module/backup_controller.php
+++ b/backup-module/backup_controller.php
@@ -92,7 +92,7 @@ function backup_controller()
     
     if ($route->action == "download") {
         header("Content-type: application/zip");
-        $backup_filename="emoncms-backup-".date("Y-m-d").".tar.gz";
+        $backup_filename="emoncms-backup-".gethostname()."-".date("Y-m-d").".tar.gz";
         header("Content-Disposition: attachment; filename=$backup_filename");
         header("Pragma: no-cache");
         header("Expires: 0");
@@ -120,7 +120,7 @@ function backup_controller()
         if ((move_uploaded_file($_FILES['file']['tmp_name'], $target_path)) && ($uploadOk == 1)) {
 
             $redis->rpush("service-runner","$import_script $import_flag>$import_logfile");
-            header('Location: '.$path.'backup#import');
+            header('Location: '.$path.'backup#import-archive');
         } else {
             return "<br><div class='alert alert-error'><b>Error:</b> Import archive not selected</div>";
         }

--- a/backup-module/backup_view.php
+++ b/backup-module/backup_view.php
@@ -161,7 +161,7 @@ function export_log_update() {
       $("#export-log").html(result);
       document.getElementById("export-log-bound").scrollTop = document.getElementById("export-log-bound").scrollHeight
 
-      if (result.indexOf("=== Emoncms export complete! ===")!=-1) {
+      if (result.indexOf("=== Emoncms export complete! ===")!=-1 || result.indexOf("=== Emoncms export completed with ERRORS! ===")!=-1) {
           clearInterval(export_updater);
       }
     }

--- a/backup-module/backup_view.php
+++ b/backup-module/backup_view.php
@@ -74,7 +74,7 @@
         <br><br>
         <pre id="export-log-bound" class="log"><div id="export-log"></div></pre>
         <?php
-        $backup_filename="emoncms-backup-".date("Y-m-d").".tar.gz";
+        $backup_filename="emoncms-backup-".gethostname()."-".date("Y-m-d").".tar.gz";
         if (file_exists($parsed_ini['backup_location']."/".$backup_filename) && !file_exists("/tmp/backuplock")) {
             echo '<br><br><b>Right Click > Download:</b><br><a href="'.$path.'backup/download">'.$backup_filename.'</a>';
         }

--- a/emoncms-export.sh
+++ b/emoncms-export.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-script_location="`dirname $0`"
+script_location="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 config_location=${script_location}/config.cfg
 
 date=$(date +"%Y-%m-%d")

--- a/emoncms-export.sh
+++ b/emoncms-export.sh
@@ -18,7 +18,7 @@ then
     echo "Location of Emoncms: $emoncms_location"
     echo "Backup destination: $backup_location"
 else
-    echo "ERROR: Backup ${config_location} file does not exist"
+    echo "ERROR: Backup config file ${config_location} does not exist"
     exit 1
     sudo systemctl start feedwriter > /dev/null
 fi

--- a/emoncms-export.sh
+++ b/emoncms-export.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
 script_location="`dirname $0`"
+config_location=${script_location}/config.cfg
 
 date=$(date +"%Y-%m-%d")
 
 echo "=== Emoncms export start ==="
 date
 echo "Backup module version:"
-cat $script_location/backup-module/module.json | grep version
+grep version ${script_location}/module.json
 echo "EUID: $EUID"
-echo "Reading $script_location/config.cfg...."
-if [ -f "$script_location/config.cfg" ]
+echo "Reading ${config_location}...."
+if [ -f "${config_location}" ]
 then
-    source "$script_location/config.cfg"
+    source "${config_location}"
     echo "Location of databases: $database_path"
     echo "Location of emonhub.conf: $emonhub_config_path"
     echo "Location of Emoncms: $emoncms_location"
     echo "Backup destination: $backup_location"
 else
-    echo "ERROR: Backup $script_location/backup/config.cfg file does not exist"
+    echo "ERROR: Backup ${config_location} file does not exist"
     exit 1
     sudo systemctl start feedwriter > /dev/null
 fi

--- a/emoncms-export.sh
+++ b/emoncms-export.sh
@@ -20,7 +20,6 @@ then
 else
     echo "ERROR: Backup config file ${config_location} does not exist"
     exit 1
-    sudo systemctl start feedwriter > /dev/null
 fi
 
 module_location="${emoncms_location}/Modules/backup"

--- a/emoncms-import.sh
+++ b/emoncms-import.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-script_location="`dirname $0`"
+script_location="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 config_location=${script_location}/config.cfg
 
 echo "=== Emoncms import start ==="

--- a/emoncms-import.sh
+++ b/emoncms-import.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
 
 script_location="`dirname $0`"
+config_location=${script_location}/config.cfg
 
 echo "=== Emoncms import start ==="
 date +"%Y-%m-%d-%T"
 echo "Backup module version:"
-cat $script_location/backup/module.json | grep version
+grep version ${script_location}/module.json
 echo "EUID: $EUID"
-echo "Reading $script_location/config.cfg...."
-if [ -f "$script_location/config.cfg" ]
+echo "Reading ${config_location}...."
+if [ -f "${config_location}" ]
 then
-    source "$script_location/config.cfg"
+    source "${config_location}"
     echo "Location of data databases: $database_path"
     echo "Location of emonhub.conf: $emonhub_config_path"
     echo "Location of Emoncms: $emoncms_location"
     echo "Backup destination: $backup_location"
     echo "Backup source path: $backup_source_path"
 else
-    echo "ERROR: Backup $script_location/backup/config.cfg file does not exist"
+    echo "ERROR: Backup ${config_location} file does not exist"
     exit 1
 fi
 

--- a/emoncms-import.sh
+++ b/emoncms-import.sh
@@ -53,8 +53,8 @@ fi
 
 
 # Get latest backup filename
-if [ ! -d $backup_source_path ]; then
-	echo "Error: $backup_source_path does not exist, nothing to import"
+if [ ! -d "${backup_source_path}" ]; then
+	echo "Error: ${backup_source_path} does not exist, nothing to import"
 	exit 1
 fi
 
@@ -69,8 +69,8 @@ fi
 echo "Backup found: ${backup_filename} starting import.."
 
 echo "Read MYSQL authentication details from settings.php"
-if [ -f $script_location/get_emoncms_mysql_auth.php ]; then
-    auth=$(echo $emoncms_location | php $script_location/get_emoncms_mysql_auth.php php)
+if [ -f "${script_location}/get_emoncms_mysql_auth.php" ]; then
+    auth=$(echo "${emoncms_location}" | php "${script_location}/get_emoncms_mysql_auth.php" php)
     IFS=":" read username password database <<< "$auth"
 else
     echo "Error: cannot read MYSQL authentication details from Emoncms settings.php"
@@ -119,7 +119,7 @@ then # if username sring is not empty
             sudo systemctl stop emoncms_mqtt
         fi
         echo "Emoncms MYSQL database import..."
-        mysql -u$username -p$password $database < "${import_location}/emoncms.sql"
+        mysql -u"${username}" -p"${password}" "${database}" < "${import_location}/emoncms.sql"
 	if [ $? -ne 0 ]; then
 		echo "Error: failed to import mysql data"
 		echo "Import failed"
@@ -135,17 +135,17 @@ else
 fi
 
 echo "Import feed meta data.."
-sudo rm -rf $database_path/{phpfina,phptimeseries} 2> /dev/null
+sudo rm -rf "${database_path}"/{phpfina,phptimeseries} 2> /dev/null
 
 echo "Restore phpfina and phptimeseries data folders..."
 if [ -d "${import_location}/phpfina" ]; then
 	sudo mv "${import_location}/phpfina" "${database_path}"
-	sudo chown -R www-data:root $database_path/phpfina
+	sudo chown -R www-data:root "${database_path}/phpfina"
 fi
 
 if [ -d "${import_location}/phptimeseries" ]; then
 	sudo mv "${import_location}/phptimeseries" "${database_path}"
-	sudo chown -R www-data:root $database_path/phptimeseries
+	sudo chown -R www-data:root "${database_path}/phptimeseries"
 fi
 
 # cleanup
@@ -156,7 +156,7 @@ if [ -f "${import_location}/emonhub.conf" ]; then
     if [ -d "${emonhub_config_path}" ]; then
         echo "Import emonhub.conf > ${emonhub_config_path}/emohub.conf"
         sudo mv "${import_location}/emonhub.conf" "${emonhub_config_path}/emonhub.conf"
-        sudo chmod 666 $emonhub_config_path/emonhub.conf
+        sudo chmod 666 "${emonhub_config_path}/emonhub.conf"
     else
         echo "WARNING: emonhub.conf found in backup, but no emonHub directory (${emonhub_config_path}) found"
     fi

--- a/emoncms-import.sh
+++ b/emoncms-import.sh
@@ -18,7 +18,7 @@ then
     echo "Backup destination: $backup_location"
     echo "Backup source path: $backup_source_path"
 else
-    echo "ERROR: Backup ${config_location} file does not exist"
+    echo "ERROR: Backup config file ${config_location} does not exist"
     exit 1
 fi
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Install this module in /opt/emoncms/modules:
     
 Run backup module installation script to modify php.ini and setup uploads folder:
 
+    cd backup
     ./install.sh
 
 ## Manual Export Instructions

--- a/usb-import.sh
+++ b/usb-import.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
 
 script_location="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+config_location=${script_location}/config.cfg
 
 echo "=== USB Emoncms import start ==="
 date +"%Y-%m-%d-%T"
 echo "Backup module version:"
-cat $script_location/backup-module/module.json | grep version
+grep version ${script_location}/module.json
 echo "EUID: $EUID"
-echo "Reading $script_location/config.cfg...."
-if [ -f "$script_location/config.cfg" ]
+echo "Reading ${config_location}...."
+if [ -f "${config_location}" ]
 then
-    source "$script_location/config.cfg"
+    source "${config_location}"
     echo "Location of data databases: $database_path"
     echo "Location of emonhub.conf: $emonhub_config_path"
     echo "Location of Emoncms: $emoncms_location"
 else
-    echo "ERROR: Backup $script_location/backup/config.cfg file does not exist"
+    echo "ERROR: Backup ${config_location} file does not exist"
     exit 1
 fi
 

--- a/usb-import.sh
+++ b/usb-import.sh
@@ -16,7 +16,7 @@ then
     echo "Location of emonhub.conf: $emonhub_config_path"
     echo "Location of Emoncms: $emoncms_location"
 else
-    echo "ERROR: Backup ${config_location} file does not exist"
+    echo "ERROR: Backup config file ${config_location} does not exist"
     exit 1
 fi
 


### PR DESCRIPTION
This PR was triggered to support issue https://github.com/emoncms/backup/issues/63, provide error checking and alerting and refine the log update window to support this.
It also build on top of PR https://github.com/emoncms/backup/pull/70

As this is such an important part of the tool and I've compared checksums of the original backup and then after imports and exports to ensure that nothing has changed between them beyond something expected or that can be justified.

The originating export was taken from a system with Emonbase and EmonTX. My test setup is a VM running Ubuntu 22.10.

The procedure followed was to:
1. Build a vanilla VM with the latest code
2. Import my original export - `/mnt/vfs_share/emoncms-backup-2023-02-23.tar.gz` below
3. Run an export, this failed due to insufficient space - handy for proving the error checking
4. Re-run export (Export 1) - `~/Downloads/emoncms-backup-emoncms-vm-2023-03-26.tar.gz` below
5. Import the Export 1
6. Run export (Export 2) - `~/Downloads/emoncms-backup-emoncms-vm-2023-03-26-1.tar.gz` below

I started by untarring the original export and collating a list of the file extracted:
```
pi@clive-ThinkPad-T470:~$ cd /tmp
pi@clive-ThinkPad-T470:/tmp$ rm -rf new* orig*
pi@clive-ThinkPad-T470:/tmp$ mkdir orig new new2
pi@clive-ThinkPad-T470:/tmp$ tar -xvf /mnt/vfs_share/emoncms-backup-2023-02-23.tar.gz -C /tmp/orig 
emoncms.sql
emonhub.conf
settings.ini
phpfina/
phpfina/19.meta
phpfina/9.dat
phpfina/62.meta
phpfina/20.dat
phpfina/50.meta
phpfina/22.meta
phpfina/48.dat
phpfina/12.meta
phpfina/10.dat
phpfina/11.meta
phpfina/17.meta
phpfina/8.dat
phpfina/62.dat
phpfina/20.meta
phpfina/7.dat
phpfina/22.dat
phpfina/14.dat
phpfina/17.dat
phpfina/18.dat
phpfina/14.meta
phpfina/11.dat
phpfina/12.dat
phpfina/50.dat
phpfina/13.dat
phpfina/48.meta
phpfina/19.dat
phpfina/21.dat
phpfina/30.meta
phpfina/13.meta
phpfina/7.meta
phpfina/21.meta
phpfina/30.dat
phpfina/10.meta
phpfina/18.meta
phpfina/9.meta
phpfina/8.meta
phpfiwa/
phptimeseries/
phptimeseries/feed_61.MYD
phptimeseries/feed_26.MYD
phptimeseries/feed_27.MYD
phptimeseries/feed_24.MYD
phptimeseries/feed_29.MYD
phptimeseries/feed_28.MYD
phptimeseries/feed_25.MYD
phptimeseries/feed_31.MYD
pi@clive-ThinkPad-T470:/tmp$ find orig/ | sed "s;orig/;;" | grep -v "^$" | sort > /tmp/orig.files
pi@clive-ThinkPad-T470:/tmp$ 
```

Then untar export 1 and collate a list of files:

```
pi@clive-ThinkPad-T470:/tmp$ tar -xvf ~/Downloads/emoncms-backup-emoncms-vm-2023-03-26.tar.gz -C /tmp/new
emoncms.sql
settings.ini
phpfina/
phpfina/14.dat
phpfina/11.dat
phpfina/10.dat
phpfina/21.dat
phpfina/62.meta
phpfina/14.meta
phpfina/18.dat
phpfina/8.meta
phpfina/18.meta
phpfina/48.dat
phpfina/19.dat
phpfina/17.meta
phpfina/17.dat
phpfina/9.dat
phpfina/22.meta
phpfina/13.meta
phpfina/7.meta
phpfina/22.dat
phpfina/7.dat
phpfina/9.meta
phpfina/30.meta
phpfina/13.dat
phpfina/10.meta
phpfina/21.meta
phpfina/12.dat
phpfina/19.meta
phpfina/8.dat
phpfina/20.meta
phpfina/11.meta
phpfina/62.dat
phpfina/30.dat
phpfina/20.dat
phpfina/50.meta
phpfina/48.meta
phpfina/50.dat
phpfina/12.meta
phpfiwa/
phptimeseries/
phptimeseries/feed_26.MYD
phptimeseries/feed_27.MYD
phptimeseries/feed_61.MYD
phptimeseries/feed_25.MYD
phptimeseries/feed_24.MYD
phptimeseries/feed_28.MYD
phptimeseries/feed_31.MYD
phptimeseries/feed_29.MYD
pi@clive-ThinkPad-T470:/tmp$ find new/ | sed "s;new/;;" | grep -v "^$" | sort > /tmp/new.files
```

Run a diff between the 2 to compare if files are missing

```
pi@clive-ThinkPad-T470:/tmp$ diff /tmp/orig.files /tmp/new.files
2d1
< emonhub.conf
pi@clive-ThinkPad-T470:/tmp$
```

emonhub.conf not found, this is expected as my test VM doesn't have emonhub installed

Create a list of MD5 checksums for all files in the original and export 1 directories, then compare the checksums:

```
pi@clive-ThinkPad-T470:/tmp$ $(cd orig && find . -type f | xargs md5sum > /tmp/orig.sum)
pi@clive-ThinkPad-T470:/tmp$ $(cd new && find . -type f | xargs md5sum > /tmp/new.sum)
pi@clive-ThinkPad-T470:/tmp$ diff orig.sum new.sum
10c10
< cecf3bc7b55f66fd7f8625af5f4bd19d  ./emoncms.sql
---
> e3d340ca7b6b9e72bd1e6b464e29f1c3  ./emoncms.sql
47d46
< 9e96449545263c5e76e3323665521d9b  ./emonhub.conf
pi@clive-ThinkPad-T470:/tmp$ 
```

Emonhub expected as it's not installed on my VM and thereby not backed up.

Run a diff on the 2 emoncms.sql:

```
pi@clive-ThinkPad-T470:/tmp$ diff orig/emoncms.sql new/emoncms.sql
1c1
< -- MySQL dump 10.17  Distrib 10.3.17-MariaDB, for debian-linux-gnueabihf (armv7l)
---
> -- MariaDB dump 10.19  Distrib 10.6.12-MariaDB, for debian-linux-gnu (x86_64)
5c5
< -- Server version	10.3.17-MariaDB-0+deb10u1
---
> -- Server version	10.6.12-MariaDB-0ubuntu0.22.10.1
28c28
< ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
65c65
< ) ENGINE=MyISAM AUTO_INCREMENT=12 DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM AUTO_INCREMENT=12 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
88c88
< ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
---
> ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
117c117
< ) ENGINE=MyISAM AUTO_INCREMENT=21 DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM AUTO_INCREMENT=21 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
152c152
< ) ENGINE=MyISAM AUTO_INCREMENT=63 DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM AUTO_INCREMENT=63 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
178c178
< ) ENGINE=MyISAM AUTO_INCREMENT=22 DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM AUTO_INCREMENT=22 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
208c208
< ) ENGINE=MyISAM AUTO_INCREMENT=529 DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM AUTO_INCREMENT=529 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
234c234
< ) ENGINE=MyISAM AUTO_INCREMENT=14 DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM AUTO_INCREMENT=14 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
257c257
< ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
282c282
< ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
310c310
< ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
332c332
< ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
357c357
< ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
399c399
< ) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
---
> ) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
421c421
< -- Dump completed on 2023-02-23 20:40:30
---
> -- Dump completed on 2023-03-26 22:02:28
pi@clive-ThinkPad-T470:/tmp$
```

The changes are due to updated software and add COLLATE or DEFAULT CHARSET to lines and different dump completion times, hence nothing untoward.

Now untar export 2 and compare file contents with export 1:

```
pi@clive-ThinkPad-T470:/tmp$ tar -xvf ~/Downloads/emoncms-backup-emoncms-vm-2023-03-26-1.tar.gz -C /tmp/new2
emoncms.sql
settings.ini
phpfina/
phpfina/14.dat
phpfina/11.dat
phpfina/10.dat
phpfina/21.dat
phpfina/62.meta
phpfina/14.meta
phpfina/18.dat
phpfina/8.meta
phpfina/18.meta
phpfina/48.dat
phpfina/19.dat
phpfina/17.meta
phpfina/17.dat
phpfina/9.dat
phpfina/22.meta
phpfina/13.meta
phpfina/7.meta
phpfina/22.dat
phpfina/7.dat
phpfina/9.meta
phpfina/30.meta
phpfina/13.dat
phpfina/10.meta
phpfina/21.meta
phpfina/12.dat
phpfina/19.meta
phpfina/8.dat
phpfina/20.meta
phpfina/11.meta
phpfina/62.dat
phpfina/30.dat
phpfina/20.dat
phpfina/50.meta
phpfina/48.meta
phpfina/50.dat
phpfina/12.meta
phpfiwa/
phptimeseries/
phptimeseries/feed_26.MYD
phptimeseries/feed_27.MYD
phptimeseries/feed_61.MYD
phptimeseries/feed_25.MYD
phptimeseries/feed_24.MYD
phptimeseries/feed_28.MYD
phptimeseries/feed_31.MYD
phptimeseries/feed_29.MYD
pi@clive-ThinkPad-T470:/tmp$ find new2/ | sed "s;new2/;;" | grep -v "^$" | sort > /tmp/new2.files
pi@clive-ThinkPad-T470:/tmp$ diff /tmp/new.files /tmp/new2.files
pi@clive-ThinkPad-T470:/tmp$
```

No changes here.

Create checksums for export 2 and compare with export 1:

```
pi@clive-ThinkPad-T470:/tmp$ $(cd new2 && find . -type f | xargs md5sum > /tmp/new2.sum)
pi@clive-ThinkPad-T470:/tmp$ diff new.sum new2.sum
10c10
< e3d340ca7b6b9e72bd1e6b464e29f1c3  ./emoncms.sql
---
> 254087cddb158a792b5bb94e5a64fb11  ./emoncms.sql
pi@clive-ThinkPad-T470:/tmp$ 
```

Only emoncms.sql different as follows:

```
pi@clive-ThinkPad-T470:/tmp$ diff new/emoncms.sql new2/emoncms.sql
421c421
< -- Dump completed on 2023-03-26 22:02:28
---
> -- Dump completed on 2023-03-26 22:21:51
pi@clive-ThinkPad-T470:/tmp$
```

The only delta being the time it ran.

Output from failed export in step 3:
```
=== Emoncms export start ===
Sun 26 Mar 22:01:23 BST 2023
Backup module version:
    "version"      : "2.3.2",
EUID: 1000
Reading /opt/emoncms/modules/backup/config.cfg....
Location of databases: /var/opt/emoncms
Location of emonhub.conf: /etc/emonhub
Location of Emoncms: /var/www/emoncms
Backup destination: /var/opt/emoncms/backup
emoncms backup module location /var/www/emoncms/Modules/backup
-- adding /var/opt/emoncms/backup/emoncms.sql to archive --
tar: Removing leading `/' from member names
/var/opt/emoncms/backup/emoncms.sql
tar: Removing leading `/' from hard link targets
no /etc/emonhub/emonhub.conf to backup
-- adding /var/www/emoncms/settings.ini to archive --
tar: Removing leading `/' from member names
/var/www/emoncms/settings.ini
tar: Removing leading `/' from hard link targets
no /var/www/emoncms/settings.php to backup
-- adding /var/opt/emoncms/phpfina to archive --
phpfina/
phpfina/14.dat
phpfina/11.dat
phpfina/10.dat
phpfina/21.dat
phpfina/62.meta
phpfina/14.meta
phpfina/18.dat
phpfina/8.meta
phpfina/18.meta
phpfina/48.dat
tar: /var/opt/emoncms/backup/emoncms-backup-emoncms-vm-2023-03-26.tar: Wrote only 8192 of 10240 bytes
tar: Error is not recoverable: exiting now
Error: RC=2 occurred on line 143
Error: failed to tar phpfina
-- adding /var/opt/emoncms/phpfiwa to archive --
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
Error: RC=2 occurred on line 143
Error: failed to tar phpfiwa
-- adding /var/opt/emoncms/phptimeseries to archive --
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
Error: RC=2 occurred on line 143
Error: failed to tar phptimeseries
Compressing archive...
/var/opt/emoncms/backup/emoncms-backup-emoncms-vm-2023-03-26.tar:	
gzip: /var/opt/emoncms/backup/emoncms-backup-emoncms-vm-2023-03-26.tar.gz: No space left on device
Error: RC=1 occurred on line 156
Error: failed to compress tar file
emoncms export failed
=== Emoncms export completed with ERRORS! ===
```

And output from successful run in step 4:
```
=== Emoncms export start ===
Sun 26 Mar 22:02:28 BST 2023
Backup module version:
    "version"      : "2.3.2",
EUID: 1000
Reading /opt/emoncms/modules/backup/config.cfg....
Location of databases: /var/opt/emoncms
Location of emonhub.conf: /etc/emonhub
Location of Emoncms: /var/www/emoncms
Backup destination: /var/opt/emoncms/backup
emoncms backup module location /var/www/emoncms/Modules/backup
-- adding /var/opt/emoncms/backup/emoncms.sql to archive --
tar: Removing leading `/' from member names
/var/opt/emoncms/backup/emoncms.sql
tar: Removing leading `/' from hard link targets
no /etc/emonhub/emonhub.conf to backup
-- adding /var/www/emoncms/settings.ini to archive --
tar: Removing leading `/' from member names
/var/www/emoncms/settings.ini
tar: Removing leading `/' from hard link targets
no /var/www/emoncms/settings.php to backup
-- adding /var/opt/emoncms/phpfina to archive --
phpfina/
phpfina/14.dat
phpfina/11.dat
phpfina/10.dat
phpfina/21.dat
phpfina/62.meta
phpfina/14.meta
phpfina/18.dat
phpfina/8.meta
phpfina/18.meta
phpfina/48.dat
phpfina/19.dat
phpfina/17.meta
phpfina/17.dat
phpfina/9.dat
phpfina/22.meta
phpfina/13.meta
phpfina/7.meta
phpfina/22.dat
phpfina/7.dat
phpfina/9.meta
phpfina/30.meta
phpfina/13.dat
phpfina/10.meta
phpfina/21.meta
phpfina/12.dat
phpfina/19.meta
phpfina/8.dat
phpfina/20.meta
phpfina/11.meta
phpfina/62.dat
phpfina/30.dat
phpfina/20.dat
phpfina/50.meta
phpfina/48.meta
phpfina/50.dat
phpfina/12.meta
-- adding /var/opt/emoncms/phpfiwa to archive --
phpfiwa/
-- adding /var/opt/emoncms/phptimeseries to archive --
phptimeseries/
phptimeseries/feed_26.MYD
phptimeseries/feed_27.MYD
phptimeseries/feed_61.MYD
phptimeseries/feed_25.MYD
phptimeseries/feed_24.MYD
phptimeseries/feed_28.MYD
phptimeseries/feed_31.MYD
phptimeseries/feed_29.MYD
Compressing archive...
/var/opt/emoncms/backup/emoncms-backup-emoncms-vm-2023-03-26.tar:	 78.3% -- replaced with /var/opt/emoncms/backup/emoncms-backup-emoncms-vm-2023-03-26.tar.gz
Backup saved: /var/opt/emoncms/backup/emoncms-backup-emoncms-vm-2023-03-26.tar.gz
Sun 26 Mar 22:03:39 BST 2023

Backup included components: /var/opt/emoncms/backup/emoncms.sql /var/www/emoncms/settings.ini phpfina phpfiwa phptimeseries
INFO: These components couldn't be found to backup: /etc/emonhub/emonhub.conf /var/www/emoncms/settings.php

Export finished...refresh page to view download link

=== Emoncms export complete! ===
