### PR TITLE
Update backup_menu.php

### DIFF
--- a/backup-module/backup_menu.php
+++ b/backup-module/backup_menu.php
@@ -1,5 +1,3 @@
 <?php
-
+global $session;
 if ($session["write"]) $menu["setup"]["l2"]['backup'] = array("name"=>"Backup","href"=>"backup", "order"=>9, "icon"=>"box-add");
-
-


### PR DESCRIPTION
to make things clean and homogeneous compared to the other modules 

for example, if you remove the admin module, backup will not work without this line

I admit very few people will remove the admin module, but working on a jetson nano, I did it as there are many commands in the admin module that are raspbian specific 

