### PR TITLE
Update emoncms-import.sh

### DIFF
--- a/emoncms-import.sh
+++ b/emoncms-import.sh
@@ -119,6 +119,12 @@ then # if username sring is not empty
             sudo systemctl stop emoncms_mqtt
         fi
         echo "Emoncms MYSQL database import..."
+
+	if grep -q "enable the sandbox mode" ${import_location}/emoncms.sql ; then
+	echo "Removing sandbox mode command from emoncms.sql dump file to maintain compatibility with older MariaDB versions"
+	sed -i 1,1d ${import_location}/emoncms.sql
+	fi
+ 
         mysql -u"${username}" -p"${password}" "${database}" < "${import_location}/emoncms.sql"
 	if [ $? -ne 0 ]; then
 		echo "Error: failed to import mysql data"


### PR DESCRIPTION
Issue: Import of backup fails due to MAriaDB version incompatibility #80
Description: Some users were not able to restore their own data after system migration.

Solution: added 4 lines of code to remove sanbox mode command from emoncms.sql, if this command was found in the dump file.

Advantage: full import compatibility with older MariaDB versions will be maintained.

Disadvantage: MariaDB security feature "sandbox mode" will be disabled.